### PR TITLE
Workflow Runner, Step Metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ MAINTAINER jspc <james@zero-internet.org.uk>
 
 ADD linux/workflow-engine /
 ENTRYPOINT ["/workflow-engine"]
+
+EXPOSE 8000 8080

--- a/job_manager.go
+++ b/job_manager.go
@@ -47,10 +47,15 @@ func (j JobManager) Consume(body string) (output map[string]interface{}, err err
 
 	output["UUID"] = jn.UUID
 	output["Register"] = jn.Register
+	output["Failed"] = false
 
 	start := time.Now().UnixNano()
 	output["Data"], err = j.JobList[jn.Type](jn)
 	end := time.Now().UnixNano()
+
+	if err != nil {
+		output["Failed"] = true
+	}
 
 	output["Duration"] = fmt.Sprintf("%d ms", (end-start)/1000000)
 

--- a/job_manager.go
+++ b/job_manager.go
@@ -49,15 +49,18 @@ func (j JobManager) Consume(body string) (output map[string]interface{}, err err
 	output["Register"] = jn.Register
 	output["Failed"] = false
 
-	start := time.Now().UnixNano()
+	start := time.Now()
 	output["Data"], err = j.JobList[jn.Type](jn)
-	end := time.Now().UnixNano()
+	end := time.Now()
 
 	if err != nil {
 		output["Failed"] = true
 	}
 
-	output["Duration"] = fmt.Sprintf("%d ms", (end-start)/1000000)
+	format := "2006-01-02T15:04:05"
+	output["Start"] = start.Format(format)
+	output["End"] = end.Format(format)
+	output["Duration"] = fmt.Sprintf("%d ms", (end.UnixNano()-start.UnixNano())/1000000)
 
 	return
 }

--- a/job_manager.go
+++ b/job_manager.go
@@ -55,6 +55,7 @@ func (j JobManager) Consume(body string) (output map[string]interface{}, err err
 
 	if err != nil {
 		output["Failed"] = true
+		output["ErrorMessage"] = err.Error()
 	}
 
 	format := "2006-01-02T15:04:05"

--- a/master_manager.go
+++ b/master_manager.go
@@ -54,6 +54,12 @@ func (m MasterManager) Consume(body string) (output map[string]interface{}, err 
 		}
 	}
 
+	if output["Failed"].(bool) {
+		wfr.Fail()
+		m.datastore.DumpWorkflowRunner(wfr)
+		return
+	}
+
 	m.datastore.DumpWorkflowRunner(wfr)
 	m.Continue(wfr.UUID)
 

--- a/master_manager.go
+++ b/master_manager.go
@@ -123,7 +123,7 @@ func (m MasterManager) Continue(uuid string) {
 		}
 
 		if err := node.Producer.send(j); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 			wfr.Fail()
 		}
 

--- a/master_manager.go
+++ b/master_manager.go
@@ -40,6 +40,10 @@ func (m MasterManager) Consume(body string) (output map[string]interface{}, err 
 		return
 	}
 
+	idx, step := wfr.Current()
+	step.SetStatus(output)
+	wfr.Workflow.Steps[idx] = step
+
 	switch output["Register"].(type) {
 	case string:
 		register := output["Register"].(string)

--- a/master_manager.go
+++ b/master_manager.go
@@ -104,6 +104,8 @@ func (m MasterManager) Continue(uuid string) {
 				step.Name,
 				err.Error(),
 			)
+
+			wfr.Fail()
 			return
 		}
 
@@ -112,11 +114,13 @@ func (m MasterManager) Continue(uuid string) {
 		j, err := compiledStep.JSON()
 		if err != nil {
 			log.Print(err)
+			wfr.Fail()
 			return
 		}
 
 		if err := node.Producer.send(j); err != nil {
 			log.Fatal(err)
+			wfr.Fail()
 		}
 
 		wfr.Last = compiledStep.Name

--- a/master_manager.go
+++ b/master_manager.go
@@ -114,6 +114,7 @@ func (m MasterManager) Continue(uuid string) {
 		}
 
 		wfr.Last = compiledStep.Name
-		m.datastore.DumpWorkflowRunner(wfr)
 	}
+
+	m.datastore.DumpWorkflowRunner(wfr)
 }

--- a/master_manager.go
+++ b/master_manager.go
@@ -97,7 +97,7 @@ func (m MasterManager) Continue(uuid string) {
 	if done {
 		wfr.End()
 	} else {
-		compiledStep, err := step.Compile(wfr.Variables)
+		err := step.Compile(wfr.Variables)
 		if err != nil {
 			log.Printf("workflow %s failed to compile step %s: %q",
 				wfr.Workflow.Name,
@@ -109,9 +109,9 @@ func (m MasterManager) Continue(uuid string) {
 			return
 		}
 
-		compiledStep.UUID = wfr.UUID
+		step.UUID = wfr.UUID
 
-		j, err := compiledStep.JSON()
+		j, err := step.JSON()
 		if err != nil {
 			log.Print(err)
 			wfr.Fail()
@@ -123,7 +123,7 @@ func (m MasterManager) Continue(uuid string) {
 			wfr.Fail()
 		}
 
-		wfr.Last = compiledStep.Name
+		wfr.Last = step.Name
 	}
 
 	m.datastore.DumpWorkflowRunner(wfr)

--- a/step.go
+++ b/step.go
@@ -24,9 +24,7 @@ type Step struct {
 // Compile ...
 // Compile, in place, `Step.Context` entry templates with
 // state data from a WorkflowRunner
-func (s *Step) Compile(v map[string]interface{}) (*Step, error) {
-	var err error
-
+func (s *Step) Compile(v map[string]interface{}) (err error) {
 	for varKey, varValue := range s.Context {
 		var buf bytes.Buffer
 
@@ -34,7 +32,7 @@ func (s *Step) Compile(v map[string]interface{}) (*Step, error) {
 
 		err = tmpl.Execute(&buf, v)
 		if err != nil {
-			return s, err
+			return
 		}
 
 		s.Context[varKey] = buf.String()

--- a/step.go
+++ b/step.go
@@ -9,11 +9,16 @@ import (
 // Step ...
 // Step configuration container
 type Step struct {
-	Context  map[string]string
-	Name     string
-	Register string
-	Type     string
-	UUID     string
+	Context      map[string]string
+	Duration     string
+	End          string
+	ErrorMessage string
+	Failed       bool
+	Name         string
+	Register     string
+	Start        string
+	Type         string
+	UUID         string
 }
 
 // Compile ...
@@ -35,7 +40,20 @@ func (s *Step) Compile(v map[string]interface{}) (*Step, error) {
 		s.Context[varKey] = buf.String()
 	}
 
-	return s, nil
+	return
+}
+
+// SetStatus receives data from job nodes and updates compiled
+// Step data within a Workflow Runner for added metadata visibility
+func (s *Step) SetStatus(m map[string]interface{}) {
+	s.Duration = m["Duration"].(string)
+	s.Start = m["Start"].(string)
+	s.End = m["End"].(string)
+	s.Failed = m["Failed"].(bool)
+
+	if s.Failed {
+		s.ErrorMessage = m["ErrorMessage"].(string)
+	}
 }
 
 // JSON ...

--- a/workflow_runner.go
+++ b/workflow_runner.go
@@ -68,6 +68,18 @@ func (wfr *WorkflowRunner) Next() (s Step, done bool) {
 	return wfr.Workflow.Steps[idx+1], false
 }
 
+// Current returns the current step. It is used, mainly,
+// after a step has returned to add extra data
+func (wfr *WorkflowRunner) Current() (i int, s Step) {
+	for i, s = range wfr.Workflow.Steps {
+		if s.Name == wfr.Last {
+			return
+		}
+	}
+
+	return
+}
+
 // Fail will set state to "failed" and end the workflow runner
 func (wfr *WorkflowRunner) Fail() {
 	wfr.endWithState("failed")

--- a/workflow_runner.go
+++ b/workflow_runner.go
@@ -10,6 +10,7 @@ import (
 // WorkflowRunner ...
 // Stateful representation of a Running Workflow
 type WorkflowRunner struct {
+	State     string
 	EndTime   time.Time
 	Last      string
 	StartTime time.Time
@@ -41,12 +42,14 @@ func ParseWorkflowRunner(data string) (wfr WorkflowRunner, err error) {
 // Put a Running Workflow into a started state
 func (wfr *WorkflowRunner) Start() {
 	wfr.StartTime = time.Now()
+	wfr.State = "started"
 }
 
 // Next ...
 // Return, should there be one, the next step of a Running Workflow
 func (wfr *WorkflowRunner) Next() (s Step, done bool) {
 	var idx int
+	wfr.State = "running"
 
 	if wfr.Last == "" {
 		return wfr.Workflow.Steps[0], false
@@ -65,8 +68,17 @@ func (wfr *WorkflowRunner) Next() (s Step, done bool) {
 	return wfr.Workflow.Steps[idx+1], false
 }
 
-// End ...
-// Put a Running Workflow into an ended state
+// Fail will set state to "failed" and end the workflow runner
+func (wfr *WorkflowRunner) Fail() {
+	wfr.endWithState("failed")
+}
+
+// End will set state to "ended" and end the workflow runner
 func (wfr *WorkflowRunner) End() {
+	wfr.endWithState("ended")
+}
+
+func (wfr *WorkflowRunner) endWithState(state string) {
 	wfr.EndTime = time.Now()
+	wfr.State = state
 }


### PR DESCRIPTION
Ensure state contains state metadata; both at the runner stage (status, timing) and per step (status, timing, error messages)

Output looks like:

```json
{
  "State": "failed",
  "EndTime": "2016-12-12T12:33:31.596812986Z",
  "Last": "Test Stuff",
  "StartTime": "2016-12-12T12:33:31.514230244Z",
  "UUID": "4927722f-f591-4aca-9e76-89f6ea452715",
  "Variables": {
    "Defaults": {
      "content_type": "application/data",
      "echo_url": "http://172.17.0.1:8000/some-endpoint"
    }
  },
  "Workflow": {
    "Name": "do stuff",
    "Steps": [
      {
        "Context": {
          "content-type": "application/data",
          "data": "foo=bar",
          "url": "http://172.17.0.1:8000/some-endpoint"
        },
        "Duration": "2 ms",
        "End": "2016-12-12T12:33:31",
        "ErrorMessage": "Post http://172.17.0.1:8000/some-endpoint: dial tcp 172.17.0.1:8000: getsockopt: connection refused",
        "Failed": true,
        "Name": "Test Stuff",
        "Register": "echo_data",
        "Start": "2016-12-12T12:33:31",
        "Type": "post-to-web",
        "UUID": ""
      },
      {
        "Context": {
          "message": "{{.echo_data.Host}}"
        },
        "Duration": "",
        "End": "",
        "ErrorMessage": "",
        "Failed": false,
        "Name": "Templatery Stuff",
        "Register": "something",
        "Start": "",
        "Type": "logz",
        "UUID": ""
      }
    ],
    "Variables": {
      "content_type": "application/data",
      "echo_url": "http://172.17.0.1:8000/some-endpoint"
    }
  }
}
```

This shows a failing workflow. The failing step is marked at the top (The last step the job tried to run). Reading the step's metadata we get a relevant error message.

Of note: the context object for step `"Templatery Stuff"` is an processed template. Templates are JIT compiled.