### PR TITLE
Trigger with data

### DIFF
--- a/master_api.go
+++ b/master_api.go
@@ -10,7 +10,8 @@ import (
 // StarterRequest ...
 // Placeholder for incoming 'start workflow' requests
 type StarterRequest struct {
-	Name string
+	Name      string
+	Variables map[string]interface{}
 }
 
 // StarterResponse ...
@@ -106,7 +107,7 @@ func (m MasterManager) getWF(uuid string) (wf interface{}) {
 }
 
 func (m MasterManager) startWF(s StarterRequest) (sr interface{}) {
-	uuid, err := m.Load(s.Name)
+	uuid, err := m.Load(s.Name, s.Variables)
 
 	if err != nil {
 		sr = ErrorResponse{err.Error()}

--- a/master_manager.go
+++ b/master_manager.go
@@ -73,13 +73,15 @@ func (m MasterManager) Consume(body string) (output map[string]interface{}, err 
 
 // Load ...
 // Load a workflow from storage and create a WorkflowRunner state machine
-func (m MasterManager) Load(name string) (uuid string, err error) {
+func (m MasterManager) Load(name string, variables map[string]interface{}) (uuid string, err error) {
 	wf, err := m.datastore.LoadWorkflow(name)
 	if err != nil {
 		return
 	}
 
 	wfr := NewWorkflowRunner(wf)
+	wfr.Variables["Runtime"] = variables
+
 	wfr.Start()
 
 	m.datastore.DumpWorkflowRunner(wfr)

--- a/workflow_runner.go
+++ b/workflow_runner.go
@@ -10,13 +10,14 @@ import (
 // WorkflowRunner ...
 // Stateful representation of a Running Workflow
 type WorkflowRunner struct {
-	State     string
-	EndTime   time.Time
-	Last      string
-	StartTime time.Time
-	UUID      string
-	Variables map[string]interface{}
-	Workflow  Workflow
+	EndTime      time.Time
+	ErrorMessage string
+	Last         string
+	StartTime    time.Time
+	State        string
+	UUID         string
+	Variables    map[string]interface{}
+	Workflow     Workflow
 }
 
 // NewWorkflowRunner ...
@@ -81,7 +82,8 @@ func (wfr *WorkflowRunner) Current() (i int, s Step) {
 }
 
 // Fail will set state to "failed" and end the workflow runner
-func (wfr *WorkflowRunner) Fail() {
+func (wfr *WorkflowRunner) Fail(msg string) {
+	wfr.ErrorMessage = msg
 	wfr.endWithState("failed")
 }
 


### PR DESCRIPTION
Kick off requests now have an optional Object containing extra vars, as specified at runtime.

```json
{
	"Name": "some set of tasks",
	"Variables": {
		"username": "foo",
		"password": "bar"
	}
}
```

Which can be accessed in step templates as per:

`"{{ .Runtime.username}}"` or `"{{.Runtime.password}}"`

(Or indeed anything: if it exists, it'll be under `.Runtime`)

Template errors will also, now, show up in `WorkflowRunner` metadata:

```json
{
  "EndTime": "2016-12-12T14:15:54.571370567Z",
  "ErrorMessage": "Templatery Stuff: template: stepContext:1:32: executing \"stepContext\" at <.Runtime.foo>: can't evaluate field foo in type interface {}",
  "Last": "Test Stuff",
  "StartTime": "2016-12-12T14:15:54.345697066Z",
  "State": "failed",
```

(snip)

With the failing step's name followed by an error message.
