### PR TITLE
Reflect correct binary name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 MAINTAINER jspc <james@zero-internet.org.uk>
 
-ADD linux/workflow-engine /
-ENTRYPOINT ["/workflow-engine"]
+ADD linux/gin /
+ENTRYPOINT ["/gin"]
 
 EXPOSE 8000 8080


### PR DESCRIPTION
https://github.com/gincorp/gin/pull/9 introduces a minor regression whereby the binary the Dockerfile expects, `workflow-engine`, doesn't exist due to the project name changing to gin.