### PR TITLE
Build only with a tag, and via a stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: go
 
+services:
+  - docker
+
+sudo: required
+
 go:
-  - 1.7.x
+  - 1.7.4
   - tip
 
 script:
   - go test -cpu=1,2 -v -tags integration ./...
 
 after_success:
-  test ! -z "$TRAVIS_TAG" && curl -s https://raw.githubusercontent.com/goreleaser/get/master/latest | bash
+  - ./script/deploy.sh
 
 notifications:
   email: false

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -axe
+
+if [[ ! -z "${TRAVIS_TAG}" && "${TRAVIS_GO_VERSION}"="1.7.4" ]]; then
+    go get -u github.com/goreleaser/releaser
+    releaser
+
+    cp -v dist/gin_Linux_x86_64/gib linux/gin
+
+    docker login docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+    docker build -t gincorp/gin .
+    docker push gincorp/gin
+fi


### PR DESCRIPTION
Current configuration triggers one release per go version, and completely ignores docker.

This PR should introduce a build against a named version of go, pref. stable, and push to the `gincorp/gin` docker repo.