### PR TITLE
Remove potentially insecure debug

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -axe
+set -e
 
 if [ ! -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_GO_VERSION}" = "1.7.4" ]; then
     go get -u github.com/goreleaser/releaser


### PR DESCRIPTION
We leaked a load of build keys in travis build. All builds have been scrubbed from dockerhub, keys/ passwords have been changed.